### PR TITLE
FIX "Publish Github Pages" Actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SSH_PORT=22
 SSH_USER = gh_euroscipy
 SSH_TARGET_DIR=/web/static/
 
-GITHUB_PAGES_BRANCH=master
+GITHUB_PAGES_BRANCH=develop
 
 DEBUG ?= 1
 ifeq ($(DEBUG), 1)


### PR DESCRIPTION
Current CI fails with:
```
ghp-import -f -p -m "Generate Pelican site" -b master /home/runner/work/euroscipy.github.io/euroscipy.github.io/output
fatal: unable to access 'https://github.com/euroscipy/euroscipy.github.io.git/': URL using bad/illegal format or missing URL
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.16/x64/bin/ghp-import", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.7.16/x64/lib/python3.7/site-packages/ghp_import.py", line 300, in main
    ghp_import(args.pop("directory"), **args)
  File "/opt/hostedtoolcache/Python/3.7.16/x64/lib/python3.7/site-packages/ghp_import.py", line 283, in ghp_import
    git.check_call('push', opts['remote'], opts['branch'], '--force')
  File "/opt/hostedtoolcache/Python/3.7.16/x64/lib/python3.7/site-packages/ghp_import.py", line 119, in check_call
    sp.check_call(['git'] + list(args), **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.16/x64/lib/python3.7/subprocess.py", line 363, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['git', 'push', 'origin', 'master', '--force']' returned non-zero exit status 128.
make: *** [Makefile:123: github] Error 1
Error: Process completed with exit code 2.
```
I'm changing `GITHUB_PAGES_BRANCH` from `master` to `develop` that should adress the issue.