### PR TITLE
Add a link to the schedule for 2023

### DIFF
--- a/content/metadata/2023/menu.yml
+++ b/content/metadata/2023/menu.yml
@@ -6,8 +6,8 @@
   submenu:
   - name: Call for Proposals
     url: program.html
-#  - name: Schedule
-#    url: https://pretalx.com/euroscipy-2023/schedule/
+  - name: Schedule
+    url: https://pretalx.com/euroscipy-2023/schedule/
   - name: Spotlights and Posters
     url: 'poster_session.html'
   - name: Sprint

--- a/content/pages/2023/maintainers.md
+++ b/content/pages/2023/maintainers.md
@@ -24,7 +24,7 @@ All the sessions will take place in the <TBA> room.
 
 ### Schedule
 
-The final schedule will be anonunced in the [Program](/2023/program_menu.html)
+The final schedule will be announced in the [Program](/2023/program_menu.html)
 section of the website once the [Call for Proposals](https://pretalx.com/euroscipy-2023/cfp)
 is closed and proposals have been reviewed and selected.
 

--- a/content/pages/2023/program_menu.md
+++ b/content/pages/2023/program_menu.md
@@ -10,6 +10,7 @@ slug: program_2023
 ### Program Items
 
 - [Call for Proposals](program.html)
+- [Schedule](https://pretalx.com/euroscipy-2023/schedule/)
 - [Spotlight and Poster Session](poster_session.html)
 - [Sprint](sprint.html)
 


### PR DESCRIPTION
This PR adds a link to the schedule for 2023.
Since we directly link to pretalx, we don't have to change anything on the website when updating the schedule.