### PR TITLE
Remove pending schedule and add sprint link

### DIFF
--- a/content/pages/2023/schedule.md
+++ b/content/pages/2023/schedule.md
@@ -9,8 +9,11 @@ slug: schedule_2023
 
 # Schedule
 
-The schedule is not yet definitive. We are waiting for all accepted talks to
-be confirmed, and the schedule might change accordingly.
+The schedule belows shows the **tutorial** and **conference** days held from August 14
+to August 17.
+<br>
+Find more information about the **sprints** on August 18
+[here](sprint.html).
 
 <div style="margin-right: 1%; padding-right: 1%">
     <pretalx-schedule


### PR DESCRIPTION
Remove the note that mentions that the schedule is not definitive.
Add a link to the cross-reference the sprints page.
We can edit the schedule on the last day of the conference with the room information.