### PR TITLE
Fix mailto.

### DIFF
--- a/content/pages/2024/contact_us.md
+++ b/content/pages/2024/contact_us.md
@@ -11,8 +11,8 @@ slug: contactus2024
 
 Contact us at one of the following mailing addresses:
 
-- for inquiries regarding the financial aid, contact us at [grants@euroscipy.org](mailto: grants@euroscipy.org)
-- for inquiries regarding the sponsorship of EuroSciPy 2024, contact us at [sponsoring@euroscipy.org](mailto: sponsoring@euroscipy.org)
-- for inquiries regarding the conference program (talks & tutorials), contact us at [program@euroscipy.org](mailto: program@euroscipy.org)
-- for inquiries regarding the sprint and the maintainer track, contact us at [maintainers@euroscipy.org](mailto: maintainers@euroscipy.org)
-- for general inquiries, contact us at [info@euroscipy.org](mailto: info@euroscipy.org)
+- for inquiries regarding the financial aid, contact us at [grants@euroscipy.org](mailto:grants@euroscipy.org)
+- for inquiries regarding the sponsorship of EuroSciPy 2024, contact us at [sponsoring@euroscipy.org](mailto:sponsoring@euroscipy.org)
+- for inquiries regarding the conference program (talks & tutorials), contact us at [program@euroscipy.org](mailto:program@euroscipy.org)
+- for inquiries regarding the sprint and the maintainer track, contact us at [maintainers@euroscipy.org](mailto:maintainers@euroscipy.org)
+- for general inquiries, contact us at [info@euroscipy.org](mailto:info@euroscipy.org)

--- a/content/pages/2024/finaid.md
+++ b/content/pages/2024/finaid.md
@@ -76,7 +76,7 @@ it with your bank, some information you can find
 - The financial aid grants will only be made available to registered attendees
 actually attending the conference
 - If you find that you cannot attend the conference for some reason, please send
-us an email to [grants@euroscipy.org](mailto: grants@euroscipy.org), so we can
+us an email to [grants@euroscipy.org](mailto:grants@euroscipy.org), so we can
 reallocate the grant
 - If the applicant does not accept the grant before the deadline, the grant will
 be considered rejected by the applicant
@@ -89,7 +89,7 @@ are not possible.
 <br>
 
 #### Contacts
-Please send an email to [grants@euroscipy.org](mailto: grants@euroscipy.org) if you have any questions.
+Please send an email to [grants@euroscipy.org](mailto:grants@euroscipy.org) if you have any questions.
 <br>
 <br>
 


### PR DESCRIPTION
The entries for `mailto:` contained a space after the `:`. This added a `%20` in front of the email address when copied from browser (right mouse button --> copy email address). Removing the space fixes this problem.