### PR TITLE
Fix/redirect2025

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,13 @@ tmp/*
 
 .DS_Store
 .idea/
+pixi.lock
+pixi.toml
+
+
+# generated
+output
+plugins
+
+# internal
+nogit_*

--- a/content/2024/about/contents.lr
+++ b/content/2024/about/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: /about
+---
+_discoverable: no

--- a/content/2024/boat_tour/contents.lr
+++ b/content/2024/boat_tour/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/childcare/contents.lr
+++ b/content/2024/childcare/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/code_of_conduct/contents.lr
+++ b/content/2024/code_of_conduct/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: /code-of-conduct
+---
+_discoverable: no

--- a/content/2024/contact_us/contents.lr
+++ b/content/2024/contact_us/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/contents.lr
+++ b/content/2024/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/current_sponsors/contents.lr
+++ b/content/2024/current_sponsors/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/featured_talks/contents.lr
+++ b/content/2024/featured_talks/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/finaid/contents.lr
+++ b/content/2024/finaid/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/index/contents.lr
+++ b/content/2024/index/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/info/contents.lr
+++ b/content/2024/info/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/keynotes/contents.lr
+++ b/content/2024/keynotes/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/lightning_talks/contents.lr
+++ b/content/2024/lightning_talks/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/maintainers/contents.lr
+++ b/content/2024/maintainers/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/organizers/contents.lr
+++ b/content/2024/organizers/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/poster_session/contents.lr
+++ b/content/2024/poster_session/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/program/contents.lr
+++ b/content/2024/program/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: /call-for-proposals
+---
+_discoverable: no

--- a/content/2024/program_menu/contents.lr
+++ b/content/2024/program_menu/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/schedule/contents.lr
+++ b/content/2024/schedule/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/social_event/contents.lr
+++ b/content/2024/social_event/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/speaker_briefing/contents.lr
+++ b/content/2024/speaker_briefing/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/sponsoring-terms/contents.lr
+++ b/content/2024/sponsoring-terms/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/sponsoring/contents.lr
+++ b/content/2024/sponsoring/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: /sponsoring
+---
+_discoverable: no

--- a/content/2024/sponsors/contents.lr
+++ b/content/2024/sponsors/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/sprint/contents.lr
+++ b/content/2024/sprint/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/tickets/contents.lr
+++ b/content/2024/tickets/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2024/venue/contents.lr
+++ b/content/2024/venue/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/about/contents.lr
+++ b/content/2025/about/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: /about
+---
+_discoverable: no

--- a/content/2025/code_of_conduct/contents.lr
+++ b/content/2025/code_of_conduct/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: /code-of-conduct
+---
+_discoverable: no

--- a/content/2025/contact_us/contents.lr
+++ b/content/2025/contact_us/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/contents.lr
+++ b/content/2025/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/current_sponsors/contents.lr
+++ b/content/2025/current_sponsors/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/finaid/contents.lr
+++ b/content/2025/finaid/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/index/contents.lr
+++ b/content/2025/index/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/info/contents.lr
+++ b/content/2025/info/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/keynotes/contents.lr
+++ b/content/2025/keynotes/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/program/contents.lr
+++ b/content/2025/program/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: /call-for-proposals
+---
+_discoverable: no

--- a/content/2025/schedule/contents.lr
+++ b/content/2025/schedule/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/social_event/contents.lr
+++ b/content/2025/social_event/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/sponsoring/contents.lr
+++ b/content/2025/sponsoring/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: /sponsoring
+---
+_discoverable: no

--- a/content/2025/sprint/contents.lr
+++ b/content/2025/sprint/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/tickets/contents.lr
+++ b/content/2025/tickets/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/content/2025/venue/contents.lr
+++ b/content/2025/venue/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: ../
+---
+_discoverable: no

--- a/models/redirect.ini
+++ b/models/redirect.ini
@@ -1,0 +1,7 @@
+[model]
+name = Redirect
+
+[fields.target]
+label = Redirect Target
+type = string
+description = Target is of type 'string' to allow relative paths. Converted to url in the template.

--- a/templates/redirect.html
+++ b/templates/redirect.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; URL='{{ this.target|url }}'" />


### PR DESCRIPTION
Add redirects for 2024 and old 2025 sites

Following the docs https://www.getlektor.com/docs/guides/redirects/ links to pages at https://euroscipy.org/2024 and https://euroscipy.org/2025 redirect to their corresponding pages on https://euroscipy.org/. Many point https://euroscipy.org/ directly.
 