### PR TITLE
Add preliminary schedule

### DIFF
--- a/assets/static/main.css
+++ b/assets/static/main.css
@@ -105,7 +105,7 @@ a {
     position: absolute;
     top: 2rem;
     left: var(--hamburger-margin);
-    z-index: 5;
+    z-index: 1000;
     cursor: pointer;
 }
 
@@ -160,7 +160,7 @@ a {
     min-height: 100vh;
     width: 100%;
     padding-left: var(--hamburger-margin);
-    z-index: 4;
+    z-index: 999;
     font-size: 3em;
     overscroll-behavior: contain;
     overflow: hidden;

--- a/content/schedule/contents.lr
+++ b/content/schedule/contents.lr
@@ -1,0 +1,6 @@
+title: EuroSciPy 2025 Schedule
+---
+body:
+
+This schedule is preliminary.
+Empty slots signify talks that the author has not confirmed yet.

--- a/content/tickets/contents.lr
+++ b/content/tickets/contents.lr
@@ -1,9 +1,11 @@
-title: EuroScipy 2025 Tickets
+title: EuroSciPy 2025 Tickets
 ---
 body:
 
-For further informations see our [FAQ](/faq).
+For further information see our [FAQ](/faq).
 
 The prices for the tickets are in złoty.
 
-We provide estimated conversions into Euro for your convenience but we do recommend that you doublecheck the current conversion rates into the currency of your choice.
+We provide estimated conversions into Euro for your convenience but we
+do recommend that you double-check the current conversion rates into
+the currency of your choice.

--- a/databags/links.json
+++ b/databags/links.json
@@ -1,6 +1,10 @@
 {
     "pages": [
         {
+            "name": "Schedule",
+            "path": "schedule"
+        },
+        {
             "name": "Tickets",
             "path": "tickets"
         },

--- a/models/schedule.ini
+++ b/models/schedule.ini
@@ -1,0 +1,12 @@
+[model]
+name = schedule
+label = Schedule
+hidden = yes
+
+[fields.title]
+label = Title
+type = string
+
+[fields.body]
+label = URL
+type = markdown

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -1,0 +1,25 @@
+{% extends "layout.html" %}
+
+{% block header %}
+<script type="text/javascript" src="https://pretalx.com/euroscipy-2025/widgets/schedule.js"></script>
+{% endblock %}
+
+{% block title %}{{ this.title }}{% endblock %}
+
+{% block body %}
+
+<div class="content">
+    {{ this.body }}
+
+    <pretalx-schedule event-url="https://pretalx.com/euroscipy-2025/" locale="en" format="grid" style="--pretalx-clr-primary: #0056aa"></pretalx-schedule>
+    <noscript>
+       <div class="pretalx-widget">
+            <div class="pretalx-widget-info-message">
+                JavaScript is disabled in your browser. To access our schedule without JavaScript,
+                please <a target="_blank" href="https://pretalx.com/euroscipy-2025/schedule/">click here</a>.
+            </div>
+        </div>
+    </noscript>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
The schedule is embedded via Javascript from pretalx. I had to increase the `z-index` of the main menu to get overlay the embedded schedule when it pops up.