### PR TITLE
Add numpy sprint

### DIFF
--- a/content/sprints/contents.lr
+++ b/content/sprints/contents.lr
@@ -66,6 +66,14 @@ TBA
 * Please see the [Good First Issue](https://github.com/scipy/scipy/contribute) for issues which can be contributed to (more) easily.
 * If you have any specific interests, please reach out to one of the hosts. We can help point you in the right direction.
 
+### NumPy
+
+* [NumPy](https://numpy.org/) is completely Free and Open Source, and a the fundamental package for scientific computing with Python.
+* Please check the [contribution documentation](https://numpy.org/devdocs/dev/index.html) for getting set up. A codespaces setup can be used in case of difficulties.
+* Issues that fit a sprint are tagged with ["sprintable" or "sprintable C"](https://github.com/numpy/numpy/issues?q=is%3Aissue%20state%3Aopen%20label%3Asprintable%20OR%20label%3A%22sprintable%20-%20C%22).
+  You may find other issues, for example documentation ones.
+* Reach out to the host before working deeply on such or other issues. Issues are often more complicated than they first seem.
+
 ### scikit-learn & scikit-image
 
 TBA


### PR DESCRIPTION
Add NumPy sprint, we can probably announce that we'll make numpy/scipy almost one, but not bad to have the separate links either way.

@mtsokol and maybe also @Kai-Striega can also help getting set up, etc. presumably.