### PR TITLE
Redirect to the archive for the past versions

### DIFF
--- a/content/2020/contents.lr
+++ b/content/2020/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: https://archive.euroscipy.org/2020/
+---
+_discoverable: no

--- a/content/2022/contents.lr
+++ b/content/2022/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: https://archive.euroscipy.org/2022/
+---
+_discoverable: no

--- a/content/2023/contents.lr
+++ b/content/2023/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: https://archive.euroscipy.org/2023/
+---
+_discoverable: no

--- a/content/2024/about.html/contents.lr
+++ b/content/2024/about.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /about
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/about/contents.lr
+++ b/content/2024/about/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /about
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/boat_tour.html/contents.lr
+++ b/content/2024/boat_tour.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/boat_tour/contents.lr
+++ b/content/2024/boat_tour/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/childcare.html/contents.lr
+++ b/content/2024/childcare.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/childcare/contents.lr
+++ b/content/2024/childcare/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/code_of_conduct.html/contents.lr
+++ b/content/2024/code_of_conduct.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /code-of-conduct
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/code_of_conduct/contents.lr
+++ b/content/2024/code_of_conduct/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /code-of-conduct
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/contact_us.html/contents.lr
+++ b/content/2024/contact_us.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/contact_us/contents.lr
+++ b/content/2024/contact_us/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/contents.lr
+++ b/content/2024/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/current_sponsors.html/contents.lr
+++ b/content/2024/current_sponsors.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/current_sponsors/contents.lr
+++ b/content/2024/current_sponsors/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/featured_talks.html/contents.lr
+++ b/content/2024/featured_talks.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/featured_talks/contents.lr
+++ b/content/2024/featured_talks/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/finaid.html/contents.lr
+++ b/content/2024/finaid.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/finaid/contents.lr
+++ b/content/2024/finaid/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/index.html/contents.lr
+++ b/content/2024/index.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/index/contents.lr
+++ b/content/2024/index/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/info.html/contents.lr
+++ b/content/2024/info.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/info/contents.lr
+++ b/content/2024/info/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/keynotes.html/contents.lr
+++ b/content/2024/keynotes.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/keynotes/contents.lr
+++ b/content/2024/keynotes/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/lightning_talks.html/contents.lr
+++ b/content/2024/lightning_talks.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/lightning_talks/contents.lr
+++ b/content/2024/lightning_talks/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/maintainers.html/contents.lr
+++ b/content/2024/maintainers.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/maintainers/contents.lr
+++ b/content/2024/maintainers/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/organizers.html/contents.lr
+++ b/content/2024/organizers.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/organizers/contents.lr
+++ b/content/2024/organizers/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/poster_session.html/contents.lr
+++ b/content/2024/poster_session.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/poster_session/contents.lr
+++ b/content/2024/poster_session/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/program.html/contents.lr
+++ b/content/2024/program.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /call-for-proposals
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/program/contents.lr
+++ b/content/2024/program/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /call-for-proposals
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/program_menu.html/contents.lr
+++ b/content/2024/program_menu.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/program_menu/contents.lr
+++ b/content/2024/program_menu/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/schedule.html/contents.lr
+++ b/content/2024/schedule.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/schedule/contents.lr
+++ b/content/2024/schedule/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/social_event.html/contents.lr
+++ b/content/2024/social_event.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/social_event/contents.lr
+++ b/content/2024/social_event/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/speaker_briefing.html/contents.lr
+++ b/content/2024/speaker_briefing.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/speaker_briefing/contents.lr
+++ b/content/2024/speaker_briefing/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/sponsoring-terms.html/contents.lr
+++ b/content/2024/sponsoring-terms.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/sponsoring-terms/contents.lr
+++ b/content/2024/sponsoring-terms/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/sponsoring.html/contents.lr
+++ b/content/2024/sponsoring.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /sponsoring
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/sponsoring/contents.lr
+++ b/content/2024/sponsoring/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /sponsoring
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/sponsors.html/contents.lr
+++ b/content/2024/sponsors.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/sponsors/contents.lr
+++ b/content/2024/sponsors/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/sprint.html/contents.lr
+++ b/content/2024/sprint.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/sprint/contents.lr
+++ b/content/2024/sprint/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/tickets.html/contents.lr
+++ b/content/2024/tickets.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/tickets/contents.lr
+++ b/content/2024/tickets/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/venue.html/contents.lr
+++ b/content/2024/venue.html/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/content/2024/venue/contents.lr
+++ b/content/2024/venue/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-target: /
+target: https://archive.euroscipy.org/2024/
 ---
 _discoverable: no

--- a/templates/redirect.html
+++ b/templates/redirect.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; URL='{{ this.target|url }}'" />
+<meta http-equiv="refresh" content="0; URL='{{ this.target }}'" />


### PR DESCRIPTION
Hi @pya,

This PR updates redirects to point to the archive. It also adds 2020, 2022 and 2023 editions redirects. 